### PR TITLE
Add CommonJS support with suite.cjs entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
       "deno": "./dist/suite.deno.js",
       "bun": "./src/suite.bun.js",
       "node": "./src/suite.node.js",
+      "require": "./src/suite.cjs",
       "types": "./src/suite.d.ts"
     },
     "./package.json": "./package.json"
@@ -34,6 +35,7 @@
     "#suite": {
       "bun": "./src/suite.bun.js",
       "node": "./src/suite.node.js",
+      "require": "./src/suite.cjs",
       "types": "./src/suite.d.ts"
     }
   }

--- a/src/suite.cjs
+++ b/src/suite.cjs
@@ -1,0 +1,24 @@
+const asserts = require('node:assert')
+const native = require('node:test')
+const {createSuite} = require('./shared.js')
+
+const test = native.test.bind()
+test.skip = native.skip
+test.only = native.only
+test.ok = asserts.ok
+test.is = asserts.strictEqual
+test.equal = asserts.deepStrictEqual
+test.throws = asserts.throws
+test.not = {
+  ok: a => asserts.ok(!a),
+  is: asserts.notStrictEqual,
+  equal: asserts.notDeepStrictEqual
+}
+test.beforeAll = native.before.bind(native)
+test.beforeEach = native.beforeEach.bind(native)
+test.afterEach = native.afterEach.bind(native)
+test.afterAll = native.after.bind(native)
+
+module.exports = {
+  suite: createSuite(() => test)
+}

--- a/suite.test.js
+++ b/suite.test.js
@@ -1,4 +1,4 @@
-import {suite} from '#suite'
+import { suite } from '#suite'
 
 const test = suite(import.meta, {
   status: '',


### PR DESCRIPTION
- Add require field to *package.json* `exports`
- Create *src/suite.cjs* with CommonJS module `exports`
- Update test imports for new module structure