### PR TITLE
Add test options parameter support

### DIFF
--- a/src/shared.js
+++ b/src/shared.js
@@ -10,10 +10,10 @@ export function createSuite(setup) {
       if ('afterAll' in ctx) test.afterAll(ctx.afterAll.bind(ctx))
     }
     return Object.assign(
-      (name, run) => {
-        return test(name, () => {
-          return run(ctx)
-        })
+      (name, options, run) => {
+        return typeof options === 'function'
+          ? test(name, () => options(ctx))
+          : test(name, options, () => run(ctx))
       },
       test,
       {

--- a/src/suite.bun.js
+++ b/src/suite.bun.js
@@ -2,9 +2,18 @@ import {createSuite} from './shared.js'
 
 export function setup(meta) {
   const native = Bun.jest(meta.path)
-  const test = native.test.bind()
-  test.skip = native.test.skip
-  test.only = native.test.only
+  const test = (name, optionsOrRun, run) =>
+    native.test(name, typeof optionsOrRun === 'function' ? optionsOrRun : run)
+  test.skip = (name, optionsOrRun, run) =>
+    native.test.skip(
+      name,
+      typeof optionsOrRun === 'function' ? optionsOrRun : run
+    )
+  test.only = (name, optionsOrRun, run) =>
+    native.test.only(
+      name,
+      typeof optionsOrRun === 'function' ? optionsOrRun : run
+    )
   test.ok = a => native.expect(a).toBeTruthy()
   test.is = (a, b) => native.expect(a).toBe(b)
   test.equal = (a, b) => native.expect(a).toEqual(b)

--- a/src/suite.d.ts
+++ b/src/suite.d.ts
@@ -1,7 +1,12 @@
 /** Describe a test */
-export interface Describe<Context = void>{
+export interface Describe<Context = void> {
   (name: string, run: (context: Context) => void | Promise<void>): void
-} 
+  (
+    name: string,
+    options: Record<string, unknown>,
+    run: (context: Context) => void | Promise<void>
+  ): void
+}
 
 interface Assert {
   /** Assert that actual is a truthy value */
@@ -46,7 +51,10 @@ export interface DefineTest<Context = void> extends Describe<Context>, Assert {
 
 /** Define a test suite */
 export interface Suite {
-  <Context extends Hooks>(meta: ImportMeta, context?: Context): DefineTest<Context>
+  <Context extends Hooks>(
+    meta: ImportMeta,
+    context?: Context
+  ): DefineTest<Context>
   (meta: ImportMeta, define: (test: DefineTest) => void): void
 }
 

--- a/suite.test.js
+++ b/suite.test.js
@@ -67,6 +67,10 @@ test('async', async () => {
   test.ok(true)
 })
 
+test('options', { timeout: 1000 }, () => {
+  test.ok(true)
+})
+
 /*test.only('only', () => {
     test.ok(true)
   })*/


### PR DESCRIPTION
## Summary
- Add support for optional test configuration parameters between test name and run function
- Enable passing test runner specific options like Node.js [`timeout`/`concurrency`/`signal`/`plan`](https://nodejs.org/docs/latest/api/test.html#testname-options-fn) or Deno [`sanitizeExit`/`sanitizeOps`/`sanitizeResources`/`permission`](https://jsr.io/@std/testing/doc/bdd#sanitization-options) while maintaining backward compatibility

## Test plan
- [x] Existing tests continue to work without modification
- [x] New test with options parameter demonstrates functionality  
- [x] TypeScript definitions updated to reflect new signature
- [x] Implementation works across all supported test runners (Bun, Node, Deno)